### PR TITLE
Fix expander capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ st.line_chart(data)
 (If you need other Python packages, add them to your `requirements.txt`)
 
 One more thing: let's say you want to execute Python code, but don't want to
-polute your Notion page with too much ugly code. There's a hack for that.
-Just put the code inside an expander **without a title.**
+pollute your Notion page with too much ugly code. There's a hack for that.
+Just put the code inside an expander **without a title or with a title equal to "Code".**
 
 
 # What's supported
@@ -69,6 +69,8 @@ Just put the code inside an expander **without a title.**
 * Images
 * Code blocks
 * Expanders
+* @user_mentions
+* @date_mentions
 
 And that's all ☹️
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -85,13 +85,14 @@ def draw_blocks(blocks):
                 st.code(txt, language=block["code"]["language"])
 
         elif block["type"] == "toggle":
-            md = get_markdown_from_text_dict(block["toggle"]["text"])
+            md = get_markdown_from_text_dict(block["toggle"]["text"]).strip().lower()
             content_blocks = notion.blocks.children.list(block["id"])
 
             if (
-                len(md.strip()) == 0
+                (len(md) == 0 or md == "code")  # Title is empty or equal to "Code"
                 and content_blocks
-                and len(content_blocks["results"]) == 1
+                and len(content_blocks["results"])
+                == 1  # Only execute if there's a single code block
             ):
                 child_block = content_blocks["results"][0]
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -85,11 +85,13 @@ def draw_blocks(blocks):
                 st.code(txt, language=block["code"]["language"])
 
         elif block["type"] == "toggle":
-            md = get_markdown_from_text_dict(block["toggle"]["text"]).strip().lower()
+            md = get_markdown_from_text_dict(block["toggle"]["text"]).strip()
             content_blocks = notion.blocks.children.list(block["id"])
 
             if (
-                (len(md) == 0 or md == "code")  # Title is empty or equal to "Code"
+                (  # Title is empty or equal to "Code"
+                    len(md) == 0 or md.lower() == "code"
+                )
                 and content_blocks
                 and len(content_blocks["results"])
                 == 1  # Only execute if there's a single code block


### PR DESCRIPTION
Moving the `lower()` call so as to avoid lowercasing normal expanders (those that are not Code expanders).